### PR TITLE
Replace click with argparse to use a single major command for everything

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,5 @@ from setuptools import setup, find_packages
 setup(
     name="sonar",
     packages=find_packages(),
-    entry_points={'console_scripts': ['sonar-snap = sonar.snap:take_snapshot']},
-    install_requires=[
-        'click==7.0',
-    ],
+    entry_points={'console_scripts': ['sonar = sonar.cli:main']}
 )

--- a/sonar/cli.py
+++ b/sonar/cli.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import argparse
+
+
+def sonar_snap(args):
+    from sonar.snap import take_snapshot
+
+    take_snapshot(output_file=args.output_file, cpu_cutoff=args.cpu_cutoff, mem_cutoff=args.mem_cutoff)
+
+
+def sonar_map(args):
+    from sonar.map import do_mapping
+
+    do_mapping(output_file=args.output_file, map_file=args.map_file, snap_dir=args.snap_dir)
+
+
+def main():
+
+    # create the top-level parser
+    parser = argparse.ArgumentParser(prog='sonar', description='Tool to profile usage of HPC resources by regularly probing processes.', epilog='Run sonar <subcommand> -h to get more information about subcommands.')
+    # Arguments common to *all* subcommands may be added to parser with parser.add_argument(...)
+    subparsers = parser.add_subparsers(title='Subcommands', metavar='')
+
+    # create the parser for the "snap" command
+    parser_snap = subparsers.add_parser('snap', help='Take a snapshot of the system. Run this on every node! Supposed to run often (e.g. every 15 minutes).')
+    parser_snap.add_argument('--output-file', default='', help='Output file. Leave empty or provide - for stdout.')
+    parser_snap.add_argument('--cpu-cutoff', type=float, default=0.5, help='CPU Memory consumption percentage cutoff (default: 0.5).')
+    parser_snap.add_argument('--mem-cutoff', type=float, default=0.0, help='Memory consumption percentage cutoff (default: 0.0).')
+    parser_snap.set_defaults(func=sonar_snap)
+
+    # create the parser for the "map" command
+    parser_map = subparsers.add_parser('map', help='Parse the system snapshots and map applications. Run this only once centrally. Supposed to run e.g. once a day.')
+    parser_map.add_argument('--snap-dir', default='', help='Path to the directory with the results of sonar snap. If empty, the current directory will be assumed.')
+    parser_map.add_argument('--output-file', default='', help='Output file. Leave empty or provide - for stdout.')
+    parser_map.add_argument('--map-file', default='', help='Path to the file with the mapping information. If empty, no mapping will be done (all apps will be "UNKNOWN").')
+    parser_map.set_defaults(func=sonar_map)
+
+    # parse some argument lists
+    args = parser.parse_args()
+
+    try:
+        args.func(args)
+    except AttributeError:
+        parser.print_help()

--- a/sonar/map.py
+++ b/sonar/map.py
@@ -11,8 +11,6 @@ from glob import glob
 from contextlib import contextmanager
 from collections import defaultdict
 
-import click
-
 
 def read_mapping(map_file):
     '''
@@ -118,13 +116,7 @@ def write_open(filename=None):
             handler.close()
 
 
-@click.command()
-@click.option('--output-file', help='Output file. Leave empty or provide - for stdout (default: -).')
-@click.option('--map_file', help='Path to the file with the mapping information. If empty, no mapping will be done.')
-@click.option('--snap_dir', required=True, help='Path to the directory with the results of sonar snap.')
-def do_mapping(output_file,
-               map_file,
-               snap_dir):
+def do_mapping(output_file, map_file, snap_dir):
     '''
     Map sonar snap results to a provided list of programs and create an output that is suitable for the dashboard etc.
     '''

--- a/sonar/snap.py
+++ b/sonar/snap.py
@@ -11,8 +11,6 @@ from contextlib import contextmanager
 from subprocess import check_output, SubprocessError, DEVNULL
 from collections import defaultdict
 
-import click
-
 
 @contextmanager
 def write_open(filename=None):
@@ -216,15 +214,9 @@ def test_create_snapshot():
         raise AssertionError
 
 
-@click.command()
-@click.option('--output-file', help='Output file. Leave empty or provide - for stdout (default: -).')
-@click.option('--cpu-cutoff', default=0.5, help='CPU Memory consumption percentage cutoff (default: 0.5).')
-@click.option('--mem-cutoff', default=0.0, help='Memory consumption percentage cutoff (default: 0.0).')
-def take_snapshot(output_file,
-                  cpu_cutoff,
-                  mem_cutoff):
+def take_snapshot(output_file, cpu_cutoff, mem_cutoff):
     '''
-    Take a snapshot of the currently running processes that use more than `cpu_cutoff` cpu and `mem_cutoff` memory.
+    Take a snapshot of the currently running processes that use more than `cpu_cutoff` cpu and `mem_cutoff` memory and save it to `output_file`.
     '''
 
     ignored_users = get_ignored_users()


### PR DESCRIPTION
Replace click with argparse to enable calling `sonar <subcommand> --arguments` instead of `sonar-<subcommand> --arguments` as before.